### PR TITLE
Fix LoadError for Redmine 4.2 and 4.1

### DIFF
--- a/lib/itamae/plugin/recipe/redmine/default.rb
+++ b/lib/itamae/plugin/recipe/redmine/default.rb
@@ -61,13 +61,13 @@ template "/opt/redmine/redmine-#{version}/config/configuration.yml" do
   mode '644'
 end
 
-if ENV['GEMFILE_LOCAL'] || version == '4.1.7'
+if ENV['GEMFILE_LOCAL'] || %w{4.1.7 4.2.11}.include?(version)
   template "/opt/redmine/redmine-#{version}/Gemfile.local" do
     user 'root'
     owner ENV['USER']
     group ENV['USER']
     mode '644'
-    source ENV['GEMFILE_LOCAL'] || ::File.join(::File.dirname(__FILE__), 'templates/Gemfile.local.erb')
+    source ENV['GEMFILE_LOCAL'] || ::File.join(::File.dirname(__FILE__), "templates/#{version}/Gemfile.local.erb")
   end
 end
 

--- a/lib/itamae/plugin/recipe/redmine/templates/4.1.7/Gemfile.local.erb
+++ b/lib/itamae/plugin/recipe/redmine/templates/4.1.7/Gemfile.local.erb
@@ -1,2 +1,5 @@
 # https://github.com/flavorjones/loofah/blob/main/CHANGELOG.md#2212--2023-05-11
 gem 'loofah', '~> 2.19.1'
+
+# https://www.redmine.org/issues/40802#note-11
+gem 'builder', '~> 3.2.4'

--- a/lib/itamae/plugin/recipe/redmine/templates/4.2.11/Gemfile.local.erb
+++ b/lib/itamae/plugin/recipe/redmine/templates/4.2.11/Gemfile.local.erb
@@ -1,0 +1,2 @@
+# https://www.redmine.org/issues/40802#note-11
+gem 'builder', '~> 3.2.4'


### PR DESCRIPTION
```
Run bundle exec rake db:create db:migrate
rake aborted!
LoadError: cannot load such file -- blankslate
/redmine/lib/redmine/views/builders/structure.rb:20:in `<top (required)>'
/redmine/lib/redmine/views/builders/json.rb:20:in `<top (required)>'
/redmine/lib/redmine/views/builders.rb:20:in `<top (required)>'
/redmine/lib/redmine.rb:64:in `<top (required)>'
/redmine/config/initializers/30-redmine.rb:7:in `<top (required)>'
```

See here for details: https://www.redmine.org/issues/40802#note-11

Assuming that there is no case to use an older patch version, the patch was applied only to the latest patch version.